### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+GenAIcode is a provider-neutral TypeScript LLM toolkit (a library), not a running
+service or UI app. There is nothing to "serve"; you develop and validate it via the npm
+scripts in `package.json`.
+
+- Standard commands live in `package.json` scripts: `npm run lint`, `npm run type-check`,
+  `npm test` (unit, vitest), `npm run build` (tsc), and `npm run check` (all of them).
+- The `genaicode` bin (`dist/cli.js`, built from `src/cli.ts`) only prints 2.x migration
+  guidance; it is not the product. The product is the library API exported from
+  `src/index.ts` and `src/providers.ts`.
+- `npm run test:e2e` hits real providers and is credential-gated: tests are skipped unless
+  provider env vars are set (`OPENAI_API_KEY`/`OPENAI_MODEL`, `ANTHROPIC_API_KEY`/`ANTHROPIC_MODEL`,
+  `GEMINI_API_KEY`/`GEMINI_MODEL`). Without keys they skip (not fail), so this is not a blocker.
+- To exercise core functionality without provider credentials, implement a small custom
+  `ModelProvider` (`{ name, async generate(request) }`) and pass it to `genaicode(provider)`.
+  This is a documented first-class extension point and runs the full prompt/chain/plugin/tool
+  code paths locally with no external calls.
+- `.nvmrc` pins Node 20, but `engines` allows `>=20`; Node 22 also works fine.
+- A husky `pre-commit` hook runs `lint-staged`, which runs `prettier --write` on staged
+  `*.{js,ts,md}`. Commits may reformat staged files.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the `genaicode` TypeScript LLM toolkit and documents durable notes for future cloud agents.

- Verified full dev workflow: install, lint, type-check, unit tests, build, and CLI run.
- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering non-obvious caveats (library not a service, credential-gated e2e tests skip without keys, custom `ModelProvider` for local core testing, husky pre-commit prettier, Node version note).
- Configured the startup update script to `npm ci` (matches committed `package-lock.json`).

## Verification

| Step | Command | Result |
| --- | --- | --- |
| Install | `npm ci` | 282 packages, OK |
| Lint | `npm run lint` | pass |
| Type-check | `npm run type-check` | pass |
| Unit tests | `npm test` | 19 passed |
| Build | `npm run build` | dist emitted |
| CLI | `node dist/cli.js` | prints 2.x migration notice |
| E2E (no keys) | `npm run test:e2e` | 3 skipped (credential-gated, expected) |

Core library functionality exercised end-to-end via a custom `ModelProvider` (callable client, conversation chain + history, plugin middleware, tool-call normalization, JSON parsing).

No application code was modified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7abc34af-b9c3-4c27-8adc-2db3129a4835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7abc34af-b9c3-4c27-8adc-2db3129a4835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

