### PR TITLE
feat: Phase 3–4 streaming, middleware, and hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,68 @@ const calls = await ai('What is the weather in Warsaw?')
 GenAIcode normalizes tool calls but deliberately does not execute them. The application
 owns permissions, retries, and side effects.
 
+## Streaming
+
+Providers that support native streaming expose a provider-neutral `StreamEvent` IR.
+Request builders and chains offer `.stream()` and `.streamText()`. If a provider has no
+`stream` method, GenAIcode synthesizes a short stream from `generate`.
+
+```ts
+for await (const event of ai('Write a haiku about queues.').stream()) {
+  if (event.type === 'text-delta') process.stdout.write(event.text);
+  if (event.type === 'done') console.log('\n', event.result.usage);
+}
+```
+
+Built-in adapters declare capability metadata:
+
+```ts
+ai.provider.capabilities;
+// { streaming: true, tools: true, images: 'input', systemPrompt: true }
+```
+
+## Middleware
+
+Hook-style plugins remain the extension point. Built-in helpers cover common backend
+needs without restoring a global registry:
+
+```ts
+import {
+  cachePlugin,
+  fallbackPlugin,
+  genaicode,
+  rateLimitPlugin,
+  timingPlugin,
+} from 'genaicode';
+import { anthropic, openai } from 'genaicode/providers';
+
+const ai = genaicode(openai({ model: 'your-model-name' }), {
+  plugins: [
+    timingPlugin(),
+    rateLimitPlugin({ concurrency: 2, minIntervalMs: 50 }),
+    cachePlugin({ maxEntries: 64 }),
+    fallbackPlugin({ providers: [anthropic({ model: 'your-claude-model' })] }),
+  ],
+});
+```
+
+## Retries
+
+Retries stay in application code. Use `classifyError`, `isRetryable`, and `withRetry`
+when you want shared classification without hidden policy:
+
+```ts
+import { withRetry } from 'genaicode';
+
+const text = await withRetry(() => ai('Summarize the deploy notes.').text(), {
+  attempts: 3,
+  delayMs: 250,
+});
+```
+
+See [retry guidance](docs/retry.md), [semver policy](docs/semver.md), and the
+[provider package evaluation](docs/provider-packages.md).
+
 ## Providers
 
 Models are provided in the adapter, through `.model(...)`, or with environment variables:
@@ -293,6 +355,7 @@ import type { ModelProvider } from 'genaicode';
 
 export const bedrock = (options: BedrockOptions): ModelProvider => ({
   name: 'bedrock',
+  capabilities: { streaming: false, tools: true, systemPrompt: true },
   async generate(request) {
     // Convert PromptItem[], call Bedrock, and return GenerationResult.
     return { parts: [{ type: 'text', text: 'response' }] };
@@ -301,7 +364,8 @@ export const bedrock = (options: BedrockOptions): ModelProvider => ({
 ```
 
 Hook-style plugins use middleware. They can observe or rewrite requests and results,
-handle errors, implement caches or fallbacks, and intentionally short-circuit a call:
+handle errors, implement caches or fallbacks, and intentionally short-circuit a call.
+Optional `stream` middleware follows the same registration order.
 
 ```ts
 import { definePlugin, genaicode } from 'genaicode';
@@ -327,6 +391,9 @@ const ai = genaicode(openai({ model: 'your-model-name' }), {
 Plugins run in registration order, and each plugin may call `next()` once. This keeps the
 extension mechanism compatible with npm packages and ordinary imports without restoring
 the 1.x runtime TypeScript loader or process-global plugin registry.
+
+Framework-shaped examples live under `examples/` (`http-handler`, `queue-worker`,
+`cron-job`).
 
 ## Design boundaries
 

--- a/docs/pivot.md
+++ b/docs/pivot.md
@@ -71,20 +71,30 @@ and in the 1.x npm line.
 - Add converter contract tests with multimodal and tool-call fixtures.
 - Keep provider SDKs isolated behind the `genaicode/providers` export.
 
-### Phase 3: backend ergonomics — in progress
+### Phase 3: backend ergonomics — implemented
 
-- Streaming with a provider-neutral event IR.
-- Middleware for observability, rate limiting, caching, and fallback.
+- Streaming with a provider-neutral event IR — implemented (`StreamEvent`,
+  `RequestBuilder.stream` / `streamText`, native provider streams with generate
+  fallback).
+- Middleware for observability, rate limiting, caching, and fallback —
+  implemented (`timingPlugin`, `rateLimitPlugin`, `cachePlugin`, `fallbackPlugin`,
+  `fallbackProvider`).
 - First-class schema adapters without requiring a specific validation library — implemented.
-- Small framework examples for HTTP handlers, queues, and cron jobs.
-- Re-evaluate separate provider packages if dependency size becomes material.
+- Small framework examples for HTTP handlers, queues, and cron jobs — implemented
+  under `examples/`.
+- Re-evaluate separate provider packages if dependency size becomes material —
+  evaluated; keep bundled for 2.x (see [provider-packages.md](./provider-packages.md)).
 
-### Phase 4: hardening
+### Phase 4: hardening — implemented
 
-- Provider capability metadata.
-- Retry classification and idempotency guidance.
-- Compatibility fixtures for multimodal and tool-call round trips.
-- Stable extension contracts and a written semver policy.
+- Provider capability metadata — implemented (`ProviderCapabilities` on
+  `ModelProvider`).
+- Retry classification and idempotency guidance — implemented
+  (`classifyError` / `withRetry` + [retry.md](./retry.md)).
+- Compatibility fixtures for multimodal and tool-call round trips — implemented
+  under `src/providers/fixtures/`.
+- Stable extension contracts and a written semver policy — implemented
+  ([semver.md](./semver.md)).
 
 ## Success measures
 

--- a/docs/provider-packages.md
+++ b/docs/provider-packages.md
@@ -1,0 +1,60 @@
+# Provider package split evaluation
+
+Phase 3 asked whether OpenAI, Anthropic, and Google adapters should move into
+separate packages to shrink the default install.
+
+## Current shape
+
+| Package surface        | Role                                      |
+| ---------------------- | ----------------------------------------- |
+| `genaicode`            | Core client, IR, plugins, middleware      |
+| `genaicode/providers`  | Adapters + public converters              |
+
+Hard dependencies today (approximate installed sizes in this repo's lockfile):
+
+- `openai` ~12MB
+- `@anthropic-ai/sdk` ~5MB
+- `@google/genai` (+ tree) ~14MB
+
+Together the provider SDKs dominate runtime dependency weight versus the small
+core TypeScript sources.
+
+## Options considered
+
+1. **Keep bundled (status quo)**  
+   One install, one version matrix, simplest DX. Cost: every consumer downloads
+   all three SDKs even if they only use one.
+
+2. **Separate packages** (`genaicode-openai`, `genaicode-anthropic`, …)  
+   Smallest installs. Cost: version skew between core and adapters, more release
+   surface, harder getting-started docs.
+
+3. **Peer dependencies + optional installs**  
+   Core stays free of SDKs; `genaicode/providers` re-exports adapters that import
+   peers. Cost: peer warnings and slightly worse first-run DX.
+
+## Decision for 2.0
+
+**Keep provider adapters bundled behind `genaicode/providers` for 2.x.**
+
+Reasons:
+
+- The product pitch is a tiny portable layer with batteries-included adapters.
+- Converter functions are part of the public compatibility story and are tested
+  together against shared fixtures.
+- Absolute weight (~30MB of SDKs) is material but still far smaller than GenAIcode
+  1.x; success measures emphasize “substantially smaller than 1.x,” not absolute
+  minimalism.
+- Splitting before streaming, middleware, and capability metadata settled would
+  freeze the wrong package boundaries.
+
+## Revisit triggers
+
+Split (or move to optional peers) when any of these become true:
+
+- Published install size or cold `npm install` time becomes a documented user pain.
+- A provider SDK forces frequent breaking upgrades independent of core.
+- Tree-shaking cannot eliminate unused SDKs for bundlers targeting edge runtimes.
+
+Until then, application authors who need a zero-SDK core can implement
+`ModelProvider` directly and ignore `genaicode/providers`.

--- a/docs/retry.md
+++ b/docs/retry.md
@@ -1,0 +1,62 @@
+# Retry classification and idempotency
+
+GenAIcode does **not** retry provider calls automatically. Retries, backoff, and
+failure budgets belong to application code so side effects stay explicit.
+
+## Classify, then decide
+
+```ts
+import { classifyError, isRetryable, withRetry } from 'genaicode';
+
+const classified = classifyError(error);
+if (classified.retryable) {
+  // transient: 408/425/429/5xx, network resets, overload heuristics
+}
+
+await withRetry(() => ai('summarize this').text(), {
+  attempts: 3,
+  delayMs: 250,
+  shouldRetry: (error) => isRetryable(error),
+});
+```
+
+`classifyError` returns `{ class, retryable, reason, status?, code?, cause }`:
+
+| Class       | Typical causes                         | Retry? |
+| ----------- | -------------------------------------- | ------ |
+| `transient` | 429, 5xx, timeouts, connection resets  | yes    |
+| `permanent` | 4xx (except above), auth, abort        | no     |
+| `unknown`   | Unrecognized shapes                    | no*    |
+
+\*Treat unknown as non-retryable by default; override with `shouldRetry` when you
+know more about your gateway.
+
+## Idempotency guidance
+
+Safe to retry without extra coordination:
+
+- Pure generation (`text`, `json`, `toolCalls` that only *propose* tool calls)
+- Read-only prompts against immutable inputs
+
+Not safe to retry blindly:
+
+- Application code that executes tool calls with side effects (writes, charges, emails)
+- Chains where a partial turn already mutated external state
+
+Patterns that keep retries safe:
+
+1. **Propose, then commit.** Let the model return a plan; apply side effects once
+   after validation.
+2. **Idempotency keys.** If a tool must run inside a retry loop, key the effect
+   (e.g. `Idempotency-Key` on a payment API) so duplicates collapse.
+3. **Outbox / queue.** Persist the intended effect before calling the provider, or
+   after a successful model response but before side effects, depending on your
+   failure mode.
+4. **Do not put retries inside plugins by default.** A retry plugin hides policy
+   from callers; prefer `withRetry` at the call site or a named, intentional plugin.
+
+## Streaming
+
+If a stream fails mid-flight, do not assume the partial text was committed anywhere.
+Re-run the full request (or resume with your own checkpointing). Conversation
+chains only append history after a successful completed turn.

--- a/docs/semver.md
+++ b/docs/semver.md
@@ -1,0 +1,55 @@
+# Semver and extension contracts
+
+GenAIcode 2.x follows semantic versioning for the published TypeScript API.
+
+## Public contracts (semver-stable)
+
+These are covered by minor/patch compatibility within 2.x:
+
+- `genaicode()` client, immutable request builders, and conversation chains
+- `PromptItem`, `GenerationRequest`, `GenerationResult`, `StreamEvent`
+- `ModelProvider` and `GenAIPlugin` interfaces
+- Prompt helpers (`prompt`, `system`, `user`, `assistant`, `asPrompt`, …)
+- Result helpers (`resultText`, `parseJsonResult`, …)
+- Built-in middleware factories (`timingPlugin`, `rateLimitPlugin`, `cachePlugin`,
+  `fallbackPlugin`, `fallbackProvider`)
+- Error helpers (`classifyError`, `isRetryable`, `withRetry`)
+- Provider factories and converter functions exported from `genaicode/providers`
+
+## Additive changes (minor)
+
+Safe in a minor release:
+
+- New optional fields on request/result/stream types
+- New optional methods on `ModelProvider` / `GenAIPlugin` (callers must feature-detect)
+- New exports and middleware helpers
+- New provider adapters behind `genaicode/providers`
+- New capability flags on `ProviderCapabilities`
+
+## Breaking changes (major)
+
+Require a new major version:
+
+- Removing or renaming exports
+- Changing the meaning of existing `PromptItem` fields
+- Making previously optional callback/plugin behavior mandatory
+- Changing default retry/side-effect policy (there is none today; introducing
+  hidden retries would be a major behavioral break)
+- Moving provider SDKs in a way that removes the current `genaicode/providers`
+  entry without a compatibility window
+
+## Non-guarantees
+
+- Exact shapes of `raw` provider payloads
+- Timing of stream events beyond the `StreamEvent` discriminant
+- Dependency versions of underlying provider SDKs within a major (may bump in
+  minors when needed for security or API drift)
+- Example apps under `examples/` (illustrative only)
+
+## Plugin and provider authors
+
+- Depend on TypeScript types from `genaicode`, not on private `dist/` paths.
+- Prefer ordinary package exports over runtime loaders.
+- Feature-detect `provider.stream` and `provider.capabilities`.
+- Treat `metadata` on `GenerationRequest` as an open bag for your middleware;
+  do not require core to understand your keys.

--- a/examples/cron-job.ts
+++ b/examples/cron-job.ts
@@ -1,0 +1,30 @@
+import { cachePlugin, genaicode, rateLimitPlugin, system, timingPlugin } from 'genaicode';
+import { openai } from 'genaicode/providers';
+
+/**
+ * Cron-style batch job: rate-limited, timed, and cached repeated prompts.
+ * Wire this from your scheduler (node-cron, systemd timer, Cloud Scheduler, etc.).
+ */
+const ai = genaicode(openai({ model: process.env.OPENAI_MODEL ?? 'your-model-name' }), {
+  plugins: [
+    timingPlugin(),
+    rateLimitPlugin({ concurrency: 2, minIntervalMs: 100 }),
+    cachePlugin({ maxEntries: 32 }),
+  ],
+});
+
+const reports = ['api latency rose 20%', 'error budget burned 8%', 'checkout conversion stable'];
+
+export async function runNightlyDigest(): Promise<string> {
+  const bullets: string[] = [];
+  for (const report of reports) {
+    bullets.push(
+      await ai.prompt(system('Rewrite as one executive bullet.'), report).text(),
+    );
+  }
+  return bullets.map((bullet) => `- ${bullet}`).join('\n');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  console.log(await runNightlyDigest());
+}

--- a/examples/http-handler.ts
+++ b/examples/http-handler.ts
@@ -1,0 +1,34 @@
+import http from 'node:http';
+import { genaicode, system } from 'genaicode';
+import { openai } from 'genaicode/providers';
+
+/**
+ * Minimal HTTP handler example.
+ *
+ * POST /summarize  body: { "text": "..." }
+ * Returns plain text.
+ */
+const ai = genaicode(openai({ model: process.env.OPENAI_MODEL ?? 'your-model-name' }), {
+  temperature: 0.2,
+});
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'POST' && req.url === '/summarize') {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) chunks.push(chunk as Buffer);
+    const body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as { text?: string };
+    const summary = await ai
+      .prompt(system('Summarize for engineers in three bullets.'), body.text ?? '')
+      .text();
+    res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
+    res.end(summary);
+    return;
+  }
+
+  res.writeHead(404).end('Not found');
+});
+
+const port = Number(process.env.PORT ?? 8787);
+server.listen(port, () => {
+  console.log(`Listening on http://localhost:${port}`);
+});

--- a/examples/queue-worker.ts
+++ b/examples/queue-worker.ts
@@ -1,0 +1,30 @@
+import { genaicode, system, withRetry } from 'genaicode';
+import { openai } from 'genaicode/providers';
+
+type Job = { id: string; text: string };
+
+/**
+ * Queue-worker style loop: pull a job, call the model, acknowledge.
+ * Retries are explicit and application-owned via `withRetry`.
+ */
+const ai = genaicode(openai({ model: process.env.OPENAI_MODEL ?? 'your-model-name' }));
+
+async function handleJob(job: Job): Promise<string> {
+  return withRetry(
+    () =>
+      ai
+        .prompt(system('Classify the support ticket as billing, bug, or question.'), job.text)
+        .text(),
+    { attempts: 3, delayMs: 200 },
+  );
+}
+
+// Stand-in for a queue client.
+async function* pullJobs(): AsyncGenerator<Job> {
+  yield { id: 'job-1', text: 'I was charged twice for last month.' };
+}
+
+for await (const job of pullJobs()) {
+  const label = await handleJob(job);
+  console.log(job.id, label);
+}

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,6 +1,7 @@
 import { assistant, prompt, system, toPromptItems } from './prompt.js';
 import { withPlugins, type GenAIPlugin } from './plugins.js';
 import { parseJsonResult, resultText, resultToPromptItem, resultToolCalls } from './result.js';
+import { providerStream, streamTextDeltas } from './stream.js';
 import type {
   GenerationDefaults,
   GenerationRequest,
@@ -9,6 +10,7 @@ import type {
   ModelProvider,
   PromptInput,
   PromptItem,
+  StreamEvent,
   ToolCall,
   ToolChoice,
   ToolDefinition,
@@ -27,6 +29,10 @@ export interface RequestBuilder {
   text(): Promise<string>;
   json<T = unknown>(parse?: JsonResultParser<T>): Promise<T>;
   toolCalls(): Promise<ToolCall[]>;
+  /** Provider-neutral streaming events (native when available, synthesized otherwise). */
+  stream(): AsyncIterable<StreamEvent>;
+  /** Convenience: yield only text deltas. */
+  streamText(): AsyncIterable<string>;
   inspect(): GenerationRequest;
 }
 
@@ -37,6 +43,8 @@ export interface Conversation {
   text(input: PromptInput, configure?: ConfigureRequest): Promise<string>;
   json<T = unknown>(input: PromptInput, parse?: JsonResultParser<T>, configure?: ConfigureRequest): Promise<T>;
   toolCalls(input: PromptInput, configure?: ConfigureRequest): Promise<ToolCall[]>;
+  stream(input: PromptInput, configure?: ConfigureRequest): AsyncIterable<StreamEvent>;
+  streamText(input: PromptInput, configure?: ConfigureRequest): AsyncIterable<string>;
   history(): PromptItem[];
   reset(...initial: PromptInput[]): void;
 }
@@ -135,6 +143,14 @@ class RequestBuilderImpl implements RequestBuilder {
   async toolCalls(): Promise<ToolCall[]> {
     return resultToolCalls(await this.run());
   }
+
+  stream(): AsyncIterable<StreamEvent> {
+    return providerStream(this.provider, this.inspect());
+  }
+
+  streamText(): AsyncIterable<string> {
+    return streamTextDeltas(this.stream());
+  }
 }
 
 class ConversationImpl implements Conversation {
@@ -177,6 +193,78 @@ class ConversationImpl implements Conversation {
 
   async toolCalls(input: PromptInput, configure?: ConfigureRequest): Promise<ToolCall[]> {
     return resultToolCalls(await this.ask(input, configure));
+  }
+
+  stream(input: PromptInput, configure: ConfigureRequest = (request) => request): AsyncIterable<StreamEvent> {
+    return this.iterateStream(input, configure);
+  }
+
+  private async *iterateStream(
+    input: PromptInput,
+    configure: ConfigureRequest,
+  ): AsyncGenerator<StreamEvent> {
+    let release: () => void = () => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const previous = this.queue;
+    this.queue = previous.then(() => gate);
+    await previous;
+
+    try {
+      const additions = toPromptItems(input);
+      const generation = this.generation;
+      const events = configure(this.createRequest(this.items, additions)).stream();
+      let text = '';
+      const toolCalls: ToolCall[] = [];
+      const images: GenerationResult['parts'] = [];
+      let usage: GenerationResult['usage'];
+      let doneResult: GenerationResult | undefined;
+
+      for await (const event of events) {
+        yield event;
+        switch (event.type) {
+          case 'text-delta':
+            text += event.text;
+            break;
+          case 'tool-call':
+            toolCalls.push(event.toolCall);
+            break;
+          case 'image':
+            images.push({ type: 'image', image: event.image });
+            break;
+          case 'usage':
+            usage = event.usage;
+            break;
+          case 'done':
+            doneResult = event.result;
+            break;
+          default:
+            break;
+        }
+      }
+
+      const result =
+        doneResult ??
+        ({
+          parts: [
+            ...(text ? [{ type: 'text' as const, text }] : []),
+            ...toolCalls.map((toolCall) => ({ type: 'toolCall' as const, toolCall })),
+            ...images,
+          ],
+          usage,
+        } satisfies GenerationResult);
+
+      if (generation === this.generation) {
+        this.items = [...this.items, ...additions, resultToPromptItem(result)];
+      }
+    } finally {
+      release();
+    }
+  }
+
+  streamText(input: PromptInput, configure?: ConfigureRequest): AsyncIterable<string> {
+    return streamTextDeltas(this.stream(input, configure));
   }
 
   history(): PromptItem[] {

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,0 +1,155 @@
+export type ErrorClass = 'transient' | 'permanent' | 'unknown';
+
+export interface ClassifiedError {
+  class: ErrorClass;
+  retryable: boolean;
+  reason: string;
+  status?: number;
+  code?: string;
+  cause: unknown;
+}
+
+function readStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const candidate = error as {
+    status?: unknown;
+    statusCode?: unknown;
+    response?: { status?: unknown };
+  };
+  for (const value of [candidate.status, candidate.statusCode, candidate.response?.status]) {
+    if (typeof value === 'number') return value;
+  }
+  return undefined;
+}
+
+function readCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' ? code : undefined;
+}
+
+function messageOf(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+/**
+ * Classify a provider/SDK error for application-owned retry loops.
+ *
+ * GenAIcode does not retry automatically. Use this helper (or your own policy)
+ * inside ordinary application control flow. See docs/retry.md.
+ */
+export function classifyError(error: unknown): ClassifiedError {
+  const status = readStatus(error);
+  const code = readCode(error);
+  const message = messageOf(error).toLowerCase();
+
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return { class: 'permanent', retryable: false, reason: 'aborted', cause: error };
+  }
+  if (code === 'ECONNRESET' || code === 'ETIMEDOUT' || code === 'ECONNREFUSED' || code === 'ENOTFOUND') {
+    return { class: 'transient', retryable: true, reason: `network:${code}`, code, cause: error };
+  }
+  if (status === 408 || status === 425 || status === 429 || (status !== undefined && status >= 500)) {
+    return {
+      class: 'transient',
+      retryable: true,
+      reason: `http:${status}`,
+      status,
+      code,
+      cause: error,
+    };
+  }
+  if (status !== undefined && status >= 400 && status < 500) {
+    return {
+      class: 'permanent',
+      retryable: false,
+      reason: `http:${status}`,
+      status,
+      code,
+      cause: error,
+    };
+  }
+  if (
+    message.includes('rate limit') ||
+    message.includes('timeout') ||
+    message.includes('temporar') ||
+    message.includes('unavailable') ||
+    message.includes('overloaded')
+  ) {
+    return { class: 'transient', retryable: true, reason: 'message-heuristic', status, code, cause: error };
+  }
+  if (
+    message.includes('invalid') ||
+    message.includes('authentication') ||
+    message.includes('unauthorized') ||
+    message.includes('permission') ||
+    message.includes('not found')
+  ) {
+    return { class: 'permanent', retryable: false, reason: 'message-heuristic', status, code, cause: error };
+  }
+
+  return { class: 'unknown', retryable: false, reason: 'unclassified', status, code, cause: error };
+}
+
+export function isRetryable(error: unknown): boolean {
+  return classifyError(error).retryable;
+}
+
+export interface RetryOptions {
+  attempts?: number;
+  /** Base delay in ms; doubles each attempt. Defaults to 250. */
+  delayMs?: number;
+  /** Max delay cap in ms. Defaults to 5000. */
+  maxDelayMs?: number;
+  shouldRetry?: (error: unknown, attempt: number) => boolean;
+  onRetry?: (info: { attempt: number; error: unknown; delayMs: number }) => void;
+  signal?: AbortSignal;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason instanceof Error ? signal.reason : new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        reject(signal.reason instanceof Error ? signal.reason : new DOMException('Aborted', 'AbortError'));
+      },
+      { once: true },
+    );
+  });
+}
+
+/**
+ * Explicit retry helper for application code. Not wired into the client by default.
+ *
+ * Idempotency: only wrap operations that are safe to repeat (most pure generation
+ * calls are; tool side effects are not unless the application makes them idempotent).
+ */
+export async function withRetry<T>(operation: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
+  const attempts = Math.max(1, options.attempts ?? 3);
+  const delayMs = options.delayMs ?? 250;
+  const maxDelayMs = options.maxDelayMs ?? 5000;
+  const shouldRetry = options.shouldRetry ?? ((error) => isRetryable(error));
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (attempt >= attempts || !shouldRetry(error, attempt)) {
+        throw error;
+      }
+      const wait = Math.min(maxDelayMs, delayMs * 2 ** (attempt - 1));
+      options.onRetry?.({ attempt, error, delayMs: wait });
+      await sleep(wait, options.signal);
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}

--- a/src/core/middleware.test.ts
+++ b/src/core/middleware.test.ts
@@ -124,6 +124,22 @@ describe('middleware plugins', () => {
     expect(maxActive).toBe(1);
   });
 
+  it('enforces minIntervalMs between successive starts', async () => {
+    const startedAt: number[] = [];
+    const provider: ModelProvider = {
+      name: 'fast',
+      async generate() {
+        startedAt.push(Date.now());
+        return { parts: [{ type: 'text', text: 'ok' }] };
+      },
+    };
+    const ai = genaicode(provider, { plugins: [rateLimitPlugin({ concurrency: 1, minIntervalMs: 40 })] });
+    await ai('a').text();
+    await ai('b').text();
+    expect(startedAt).toHaveLength(2);
+    expect(startedAt[1]! - startedAt[0]!).toBeGreaterThanOrEqual(35);
+  });
+
   it('falls back to alternate providers', async () => {
     const primary: ModelProvider = {
       name: 'primary',
@@ -144,6 +160,33 @@ describe('middleware plugins', () => {
     ).resolves.toMatchObject({
       parts: [{ type: 'text', text: 'fallback' }],
     });
+  });
+
+  it('streams from the first provider that implements stream()', async () => {
+    const generateOnly: ModelProvider = {
+      name: 'generate-only',
+      async generate() {
+        return { parts: [{ type: 'text', text: 'generate' }] };
+      },
+    };
+    const streaming: ModelProvider = {
+      name: 'streaming',
+      async generate() {
+        return { parts: [{ type: 'text', text: 'unused' }] };
+      },
+      async *stream() {
+        yield { type: 'text-delta', text: 'native' };
+        yield { type: 'done', result: { parts: [{ type: 'text', text: 'native' }] } };
+      },
+    };
+
+    const events: string[] = [];
+    for await (const event of fallbackProvider([generateOnly, streaming]).stream!({
+      prompt: [{ type: 'user', text: 'q' }],
+    })) {
+      if (event.type === 'text-delta') events.push(event.text);
+    }
+    expect(events).toEqual(['native']);
   });
 });
 

--- a/src/core/middleware.test.ts
+++ b/src/core/middleware.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from 'vitest';
+import { genaicode } from './client.js';
+import { classifyError, isRetryable, withRetry } from './errors.js';
+import { cachePlugin, fallbackPlugin, fallbackProvider, rateLimitPlugin, timingPlugin } from './middleware.js';
+import { collectStream } from './stream.js';
+import type { GenerationRequest, GenerationResult, ModelProvider, StreamEvent } from './types.js';
+
+function sequenceProvider(results: GenerationResult[], streamChunks?: StreamEvent[][]) {
+  const requests: GenerationRequest[] = [];
+  const provider: ModelProvider = {
+    name: 'test',
+    capabilities: { streaming: Boolean(streamChunks), tools: true, systemPrompt: true },
+    async generate(request) {
+      requests.push(request);
+      const result = results.shift();
+      if (!result) throw new Error('No test result configured.');
+      return result;
+    },
+    async *stream(request) {
+      requests.push(request);
+      const chunks = streamChunks?.shift();
+      if (chunks) {
+        for (const chunk of chunks) yield chunk;
+        return;
+      }
+      const result = results.shift();
+      if (!result) throw new Error('No test result configured.');
+      yield { type: 'done', result };
+    },
+  };
+  return { provider, requests };
+}
+
+describe('streaming', () => {
+  it('exposes native stream events from the request builder', async () => {
+    const { provider } = sequenceProvider([], [
+      [
+        { type: 'text-delta', text: 'hel' },
+        { type: 'text-delta', text: 'lo' },
+        { type: 'done', result: { parts: [{ type: 'text', text: 'hello' }] } },
+      ],
+    ]);
+    const ai = genaicode(provider);
+    const events: StreamEvent['type'][] = [];
+    let text = '';
+    for await (const event of ai('hi').stream()) {
+      events.push(event.type);
+      if (event.type === 'text-delta') text += event.text;
+    }
+    expect(text).toBe('hello');
+    expect(events).toEqual(['text-delta', 'text-delta', 'done']);
+  });
+
+  it('synthesizes a stream when the provider only implements generate', async () => {
+    const provider: ModelProvider = {
+      name: 'generate-only',
+      async generate() {
+        return { parts: [{ type: 'text', text: 'snapshot' }] };
+      },
+    };
+    const result = await collectStream(genaicode(provider)('q').stream());
+    expect(result.parts).toEqual([{ type: 'text', text: 'snapshot' }]);
+  });
+
+  it('updates conversation history after a streamed turn', async () => {
+    const { provider } = sequenceProvider([], [
+      [{ type: 'text-delta', text: 'one' }, { type: 'done', result: { parts: [{ type: 'text', text: 'one' }] } }],
+    ]);
+    const chain = genaicode(provider).chain();
+    const pieces: string[] = [];
+    for await (const delta of chain.streamText('prompt')) {
+      pieces.push(delta);
+    }
+    expect(pieces).toEqual(['one']);
+    expect(chain.history()).toEqual([
+      { type: 'user', text: 'prompt' },
+      { type: 'assistant', text: 'one', images: [], toolCalls: [] },
+    ]);
+  });
+});
+
+describe('middleware plugins', () => {
+  it('times generate calls', async () => {
+    const timings: number[] = [];
+    const { provider } = sequenceProvider([{ parts: [{ type: 'text', text: 'ok' }] }]);
+    const ai = genaicode(provider, {
+      plugins: [timingPlugin({ onTiming: (info) => timings.push(info.durationMs) })],
+    });
+    await expect(ai('x').text()).resolves.toBe('ok');
+    expect(timings).toHaveLength(1);
+    expect(timings[0]).toBeGreaterThanOrEqual(0);
+  });
+
+  it('caches identical requests', async () => {
+    let calls = 0;
+    const provider: ModelProvider = {
+      name: 'counting',
+      async generate() {
+        calls += 1;
+        return { parts: [{ type: 'text', text: 'cached-value' }] };
+      },
+    };
+    const ai = genaicode(provider, { plugins: [cachePlugin()] });
+    await expect(ai('same').text()).resolves.toBe('cached-value');
+    await expect(ai('same').text()).resolves.toBe('cached-value');
+    expect(calls).toBe(1);
+  });
+
+  it('rate-limits concurrent calls', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const provider: ModelProvider = {
+      name: 'slow',
+      async generate() {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        active -= 1;
+        return { parts: [{ type: 'text', text: 'ok' }] };
+      },
+    };
+    const ai = genaicode(provider, { plugins: [rateLimitPlugin({ concurrency: 1 })] });
+    await Promise.all([ai('a').text(), ai('b').text(), ai('c').text()]);
+    expect(maxActive).toBe(1);
+  });
+
+  it('falls back to alternate providers', async () => {
+    const primary: ModelProvider = {
+      name: 'primary',
+      async generate() {
+        throw Object.assign(new Error('boom'), { status: 500 });
+      },
+    };
+    const secondary: ModelProvider = {
+      name: 'secondary',
+      async generate() {
+        return { parts: [{ type: 'text', text: 'fallback' }] };
+      },
+    };
+    const ai = genaicode(primary, { plugins: [fallbackPlugin({ providers: [secondary] })] });
+    await expect(ai('q').text()).resolves.toBe('fallback');
+    await expect(
+      fallbackProvider([primary, secondary]).generate({ prompt: [{ type: 'user', text: 'q' }] }),
+    ).resolves.toMatchObject({
+      parts: [{ type: 'text', text: 'fallback' }],
+    });
+  });
+});
+
+describe('retry classification', () => {
+  it('classifies transient and permanent errors', () => {
+    expect(classifyError(Object.assign(new Error('rate'), { status: 429 })).retryable).toBe(true);
+    expect(classifyError(Object.assign(new Error('bad'), { status: 400 })).retryable).toBe(false);
+    expect(isRetryable(Object.assign(new Error('timeout'), { code: 'ETIMEDOUT' }))).toBe(true);
+  });
+
+  it('retries transient failures with withRetry', async () => {
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error('busy'), { status: 503 }))
+      .mockResolvedValueOnce('ok');
+    await expect(withRetry(operation, { attempts: 3, delayMs: 1 })).resolves.toBe('ok');
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/core/middleware.ts
+++ b/src/core/middleware.ts
@@ -48,8 +48,10 @@ export function rateLimitPlugin(options: RateLimitPluginOptions = {}): GenAIPlug
   const pump = () => {
     while (active < concurrency && waiters.length > 0) {
       const now = Date.now();
-      const waitMs = Math.max(0, minIntervalMs - (now - lastStartedAt));
-      if (waitMs > 0 && active > 0) {
+      // Enforce spacing between starts even when no call is currently in flight
+      // (important for concurrency=1 + minIntervalMs).
+      const waitMs = lastStartedAt === 0 ? 0 : Math.max(0, minIntervalMs - (now - lastStartedAt));
+      if (waitMs > 0) {
         setTimeout(pump, waitMs);
         return;
       }
@@ -174,11 +176,11 @@ export function fallbackProvider(providers: readonly ModelProvider[], name = 'fa
   if (providers.length === 0) {
     throw new Error('fallbackProvider requires at least one provider.');
   }
-  const [primary] = providers;
+  const streamProvider = providers.find((provider) => Boolean(provider.stream)) ?? providers[0];
   return {
     name,
     capabilities: {
-      streaming: providers.every((provider) => provider.capabilities?.streaming || Boolean(provider.stream)),
+      streaming: providers.some((provider) => provider.capabilities?.streaming || Boolean(provider.stream)),
       tools: providers.every((provider) => provider.capabilities?.tools !== false),
       systemPrompt: providers.every((provider) => provider.capabilities?.systemPrompt !== false),
     },
@@ -194,8 +196,8 @@ export function fallbackProvider(providers: readonly ModelProvider[], name = 'fa
       throw lastError instanceof Error ? lastError : new Error(String(lastError));
     },
     stream(request) {
-      // Stream from the first provider that exposes streaming; otherwise synthesize.
-      return providerStream(primary, request);
+      // Prefer the first provider with a native stream implementation.
+      return providerStream(streamProvider, request);
     },
   };
 }

--- a/src/core/middleware.ts
+++ b/src/core/middleware.ts
@@ -1,0 +1,201 @@
+import type { GenerationRequest, GenerationResult, ModelProvider } from './types.js';
+import { definePlugin, type GenAIPlugin } from './plugins.js';
+import { providerStream } from './stream.js';
+
+export interface TimingPluginOptions {
+  onTiming?: (info: { plugin: string; provider?: string; durationMs: number; ok: boolean }) => void;
+}
+
+/** Observability middleware: records wall-clock duration around each generate call. */
+export function timingPlugin(options: TimingPluginOptions = {}): GenAIPlugin {
+  const onTiming =
+    options.onTiming ??
+    ((info) => {
+      console.log(`[genaicode] ${info.plugin} ${info.ok ? 'ok' : 'error'} in ${info.durationMs.toFixed(1)}ms`);
+    });
+
+  return definePlugin({
+    name: 'timing',
+    async generate(request, next) {
+      const startedAt = performance.now();
+      try {
+        const result = await next(request);
+        onTiming({ plugin: 'timing', durationMs: performance.now() - startedAt, ok: true });
+        return result;
+      } catch (error) {
+        onTiming({ plugin: 'timing', durationMs: performance.now() - startedAt, ok: false });
+        throw error;
+      }
+    },
+  });
+}
+
+export interface RateLimitPluginOptions {
+  /** Maximum concurrent in-flight generate calls. Defaults to 1. */
+  concurrency?: number;
+  /** Minimum delay between starting successive calls, in milliseconds. */
+  minIntervalMs?: number;
+}
+
+/** Simple concurrency / interval limiter. Does not talk to external rate-limit stores. */
+export function rateLimitPlugin(options: RateLimitPluginOptions = {}): GenAIPlugin {
+  const concurrency = Math.max(1, options.concurrency ?? 1);
+  const minIntervalMs = Math.max(0, options.minIntervalMs ?? 0);
+  let active = 0;
+  let lastStartedAt = 0;
+  const waiters: Array<() => void> = [];
+
+  const pump = () => {
+    while (active < concurrency && waiters.length > 0) {
+      const now = Date.now();
+      const waitMs = Math.max(0, minIntervalMs - (now - lastStartedAt));
+      if (waitMs > 0 && active > 0) {
+        setTimeout(pump, waitMs);
+        return;
+      }
+      const next = waiters.shift();
+      if (!next) return;
+      active += 1;
+      lastStartedAt = Date.now();
+      next();
+    }
+  };
+
+  const acquire = () =>
+    new Promise<void>((resolve) => {
+      waiters.push(resolve);
+      pump();
+    });
+
+  const release = () => {
+    active = Math.max(0, active - 1);
+    pump();
+  };
+
+  return definePlugin({
+    name: 'rate-limit',
+    async generate(request, next) {
+      await acquire();
+      try {
+        return await next(request);
+      } finally {
+        release();
+      }
+    },
+  });
+}
+
+export interface CachePluginOptions {
+  /** Stable cache key. Defaults to a JSON serialization of the request (excluding signal). */
+  key?: (request: GenerationRequest) => string;
+  maxEntries?: number;
+}
+
+function defaultCacheKey(request: GenerationRequest): string {
+  return JSON.stringify({
+    prompt: request.prompt,
+    model: request.model,
+    temperature: request.temperature,
+    maxOutputTokens: request.maxOutputTokens,
+    tools: request.tools,
+    toolChoice: request.toolChoice,
+    metadata: request.metadata,
+  });
+}
+
+/** In-memory response cache. Intentionally short-circuits `next` on hit. */
+export function cachePlugin(options: CachePluginOptions = {}): GenAIPlugin {
+  const keyOf = options.key ?? defaultCacheKey;
+  const maxEntries = options.maxEntries ?? 128;
+  const cache = new Map<string, GenerationResult>();
+
+  return definePlugin({
+    name: 'cache',
+    async generate(request, next) {
+      const key = keyOf(request);
+      const hit = cache.get(key);
+      if (hit) {
+        cache.delete(key);
+        cache.set(key, hit);
+        return hit;
+      }
+      const result = await next(request);
+      cache.set(key, result);
+      if (cache.size > maxEntries) {
+        const oldest = cache.keys().next().value;
+        if (oldest !== undefined) cache.delete(oldest);
+      }
+      return result;
+    },
+  });
+}
+
+export interface FallbackPluginOptions {
+  /** Additional providers tried after the primary provider fails. */
+  providers: readonly ModelProvider[];
+  /** Decide whether an error should trigger fallback. Defaults to always. */
+  shouldFallback?: (error: unknown, attempt: number) => boolean;
+}
+
+/**
+ * Fallback middleware: on primary failure, try alternate providers in order.
+ * Each alternate receives the same GenerationRequest.
+ */
+export function fallbackPlugin(options: FallbackPluginOptions): GenAIPlugin {
+  const shouldFallback = options.shouldFallback ?? (() => true);
+
+  return definePlugin({
+    name: 'fallback',
+    async generate(request, next) {
+      try {
+        return await next(request);
+      } catch (error) {
+        if (!shouldFallback(error, 0)) throw error;
+        let lastError: unknown = error;
+        for (let index = 0; index < options.providers.length; index += 1) {
+          if (!shouldFallback(lastError, index + 1) && index > 0) throw lastError;
+          try {
+            return await options.providers[index].generate(request);
+          } catch (fallbackError) {
+            lastError = fallbackError;
+          }
+        }
+        throw lastError;
+      }
+    },
+  });
+}
+
+/**
+ * Compose multiple providers into one ModelProvider that tries each until one succeeds.
+ * Prefer this when there is no single "primary" provider wired through plugins.
+ */
+export function fallbackProvider(providers: readonly ModelProvider[], name = 'fallback'): ModelProvider {
+  if (providers.length === 0) {
+    throw new Error('fallbackProvider requires at least one provider.');
+  }
+  const [primary] = providers;
+  return {
+    name,
+    capabilities: {
+      streaming: providers.every((provider) => provider.capabilities?.streaming || Boolean(provider.stream)),
+      tools: providers.every((provider) => provider.capabilities?.tools !== false),
+      systemPrompt: providers.every((provider) => provider.capabilities?.systemPrompt !== false),
+    },
+    async generate(request) {
+      let lastError: unknown;
+      for (const provider of providers) {
+        try {
+          return await provider.generate(request);
+        } catch (error) {
+          lastError = error;
+        }
+      }
+      throw lastError instanceof Error ? lastError : new Error(String(lastError));
+    },
+    stream(request) {
+      // Stream from the first provider that exposes streaming; otherwise synthesize.
+      return providerStream(primary, request);
+    },
+  };
+}

--- a/src/core/plugins.ts
+++ b/src/core/plugins.ts
@@ -1,10 +1,17 @@
-import type { GenerationRequest, GenerationResult, ModelProvider } from './types.js';
+import { generateAsStream, providerStream } from './stream.js';
+import type { GenerationRequest, GenerationResult, ModelProvider, StreamEvent } from './types.js';
 
 export type GenerateNext = (request?: GenerationRequest) => Promise<GenerationResult>;
+export type StreamNext = (request?: GenerationRequest) => AsyncIterable<StreamEvent>;
 
 export interface GenAIPlugin {
   readonly name: string;
   generate(request: GenerationRequest, next: GenerateNext): Promise<GenerationResult>;
+  /**
+   * Optional streaming middleware. When omitted, the stream path passes through
+   * to the next plugin / provider unchanged.
+   */
+  stream?(request: GenerationRequest, next: StreamNext): AsyncIterable<StreamEvent>;
 }
 
 export function definePlugin(plugin: GenAIPlugin): GenAIPlugin {
@@ -16,12 +23,14 @@ export function definePlugin(plugin: GenAIPlugin): GenAIPlugin {
  *
  * Plugins run in registration order. Each plugin may modify the request passed
  * to `next`, transform its result, handle an error, or intentionally short-circuit.
+ * Streaming uses the same order; plugins without `stream` pass through.
  */
 export function withPlugins(provider: ModelProvider, plugins: readonly GenAIPlugin[]): ModelProvider {
   if (plugins.length === 0) return provider;
 
-  return {
+  const wrapped: ModelProvider = {
     name: provider.name,
+    capabilities: provider.capabilities,
     generate(request) {
       let lastIndex = -1;
       const dispatch = (index: number, currentRequest: GenerationRequest): Promise<GenerationResult> => {
@@ -35,5 +44,27 @@ export function withPlugins(provider: ModelProvider, plugins: readonly GenAIPlug
       };
       return dispatch(0, request);
     },
+    stream(request) {
+      let lastIndex = -1;
+      const dispatch = (index: number, currentRequest: GenerationRequest): AsyncIterable<StreamEvent> => {
+        if (index <= lastIndex) {
+          throw new Error('A GenAIcode plugin called next() more than once.');
+        }
+        lastIndex = index;
+        const plugin = plugins[index];
+        if (!plugin) {
+          return provider.stream
+            ? providerStream(provider, currentRequest)
+            : generateAsStream((nextRequest) => provider.generate(nextRequest), currentRequest);
+        }
+        if (plugin.stream) {
+          return plugin.stream(currentRequest, (nextRequest = currentRequest) => dispatch(index + 1, nextRequest));
+        }
+        return dispatch(index + 1, currentRequest);
+      };
+      return dispatch(0, request);
+    },
   };
+
+  return wrapped;
 }

--- a/src/core/stream.ts
+++ b/src/core/stream.ts
@@ -1,0 +1,104 @@
+import { resultText, resultToolCalls } from './result.js';
+import type { GenerationResult, ModelProvider, StreamEvent, ToolCall } from './types.js';
+
+/**
+ * Turn a completed generation into a short synthetic stream.
+ * Used when a provider (or plugin chain) has no native `stream` implementation.
+ */
+export async function* generateAsStream(
+  generate: (request: Parameters<ModelProvider['generate']>[0]) => Promise<GenerationResult>,
+  request: Parameters<ModelProvider['generate']>[0],
+): AsyncGenerator<StreamEvent> {
+  try {
+    const result = await generate(request);
+    const text = resultText(result);
+    if (text) {
+      yield { type: 'text-delta', text };
+    }
+    for (const toolCall of resultToolCalls(result)) {
+      yield { type: 'tool-call', toolCall };
+    }
+    for (const part of result.parts) {
+      if (part.type === 'image') {
+        yield { type: 'image', image: part.image };
+      }
+    }
+    if (result.usage) {
+      yield { type: 'usage', usage: result.usage };
+    }
+    yield { type: 'done', result };
+  } catch (error) {
+    yield { type: 'error', error };
+    throw error;
+  }
+}
+
+export function providerStream(
+  provider: ModelProvider,
+  request: Parameters<ModelProvider['generate']>[0],
+): AsyncIterable<StreamEvent> {
+  if (provider.stream) {
+    return provider.stream(request);
+  }
+  return generateAsStream((nextRequest) => provider.generate(nextRequest), request);
+}
+
+/** Collect a stream into the final `GenerationResult` (from `done` or by accumulation). */
+export async function collectStream(events: AsyncIterable<StreamEvent>): Promise<GenerationResult> {
+  let text = '';
+  const toolCalls: ToolCall[] = [];
+  const images: GenerationResult['parts'] = [];
+  let usage: GenerationResult['usage'];
+  let model: string | undefined;
+  let finishReason: string | undefined;
+  let raw: unknown;
+  let doneResult: GenerationResult | undefined;
+
+  for await (const event of events) {
+    switch (event.type) {
+      case 'text-delta':
+        text += event.text;
+        break;
+      case 'tool-call':
+        toolCalls.push(event.toolCall);
+        break;
+      case 'image':
+        images.push({ type: 'image', image: event.image });
+        break;
+      case 'usage':
+        usage = event.usage;
+        break;
+      case 'done':
+        doneResult = event.result;
+        break;
+      case 'error':
+        throw event.error instanceof Error ? event.error : new Error(String(event.error));
+      case 'tool-call-delta':
+        break;
+    }
+  }
+
+  if (doneResult) {
+    return doneResult;
+  }
+
+  const parts: GenerationResult['parts'] = [];
+  if (text) parts.push({ type: 'text', text });
+  for (const toolCall of toolCalls) {
+    parts.push({ type: 'toolCall', toolCall });
+  }
+  parts.push(...images);
+
+  return { parts, model, finishReason, usage, raw };
+}
+
+/** Yield only text deltas from a stream. */
+export async function* streamTextDeltas(events: AsyncIterable<StreamEvent>): AsyncGenerator<string> {
+  for await (const event of events) {
+    if (event.type === 'text-delta' && event.text) {
+      yield event.text;
+    } else if (event.type === 'error') {
+      throw event.error instanceof Error ? event.error : new Error(String(event.error));
+    }
+  }
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -111,9 +111,41 @@ export interface GenerationRequest {
   metadata?: Record<string, unknown>;
 }
 
+/**
+ * Provider-neutral streaming event IR.
+ *
+ * Providers may emit deltas as they arrive. Consumers that only need the final
+ * answer can ignore intermediate events and wait for `done`.
+ */
+export type StreamEvent =
+  | { type: 'text-delta'; text: string }
+  | { type: 'tool-call-delta'; id?: string; name?: string; argumentsDelta?: string }
+  | { type: 'tool-call'; toolCall: ToolCall }
+  | { type: 'image'; image: PromptImage }
+  | { type: 'usage'; usage: TokenUsage }
+  | { type: 'error'; error: unknown }
+  | { type: 'done'; result: GenerationResult };
+
+export interface ProviderCapabilities {
+  /** Native token streaming via `ModelProvider.stream`. */
+  streaming?: boolean;
+  /** Function/tool calling. */
+  tools?: boolean;
+  /** Image input, output, both, or none. */
+  images?: false | 'input' | 'output' | 'both';
+  /** First-class system prompt / instruction support. */
+  systemPrompt?: boolean;
+}
+
 export interface ModelProvider {
   readonly name: string;
+  readonly capabilities?: ProviderCapabilities;
   generate(request: GenerationRequest): Promise<GenerationResult>;
+  /**
+   * Optional native streaming. When omitted, GenAIcode synthesizes a short
+   * stream from `generate` (single text snapshot + `done`).
+   */
+  stream?(request: GenerationRequest): AsyncIterable<StreamEvent>;
 }
 
 export interface GenerationDefaults {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,23 @@
 export { genaicode } from './core/client.js';
 export type { ConfigureRequest, Conversation, GenAIClient, GenAIClientOptions, RequestBuilder } from './core/client.js';
+export { classifyError, isRetryable, withRetry } from './core/errors.js';
+export type { ClassifiedError, ErrorClass, RetryOptions } from './core/errors.js';
+export {
+  cachePlugin,
+  fallbackPlugin,
+  fallbackProvider,
+  rateLimitPlugin,
+  timingPlugin,
+} from './core/middleware.js';
+export type {
+  CachePluginOptions,
+  FallbackPluginOptions,
+  RateLimitPluginOptions,
+  TimingPluginOptions,
+} from './core/middleware.js';
 export { definePlugin, withPlugins } from './core/plugins.js';
-export type { GenAIPlugin, GenerateNext } from './core/plugins.js';
+export type { GenAIPlugin, GenerateNext, StreamNext } from './core/plugins.js';
 export { asPrompt, assistant, image, prompt, system, toolResults, toPromptItems, user } from './core/prompt.js';
 export { parseJsonResult, resultText, resultToPromptItem, resultToolCalls } from './core/result.js';
+export { collectStream, generateAsStream, providerStream, streamTextDeltas } from './core/stream.js';
 export * from './core/types.js';

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -21,8 +21,10 @@ export { openai, openaiCompatible } from './providers/openai.js';
 export type { OpenAICompatibleProviderOptions, OpenAIProviderOptions } from './providers/openai.js';
 export {
   fromOpenAICompletion,
+  fromOpenAIStream,
   toOpenAIMessages,
   toOpenAIRequest,
+  toOpenAIStreamRequest,
   toOpenAIToolChoice,
   toOpenAITools,
 } from './providers/openai-converter.js';

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -1,6 +1,10 @@
 import Anthropic from '@anthropic-ai/sdk';
-import type { ModelProvider } from '../core/types.js';
-import { fromAnthropicMessage, toAnthropicRequest, type AnthropicRequestDefaults } from './anthropic-converter.js';
+import type { ModelProvider, StreamEvent } from '../core/types.js';
+import {
+  fromAnthropicMessage,
+  toAnthropicRequest,
+  type AnthropicRequestDefaults,
+} from './anthropic-converter.js';
 
 export interface AnthropicProviderOptions {
   apiKey?: string;
@@ -20,6 +24,12 @@ export function anthropic(options: AnthropicProviderOptions = {}): ModelProvider
 
   return {
     name: 'anthropic',
+    capabilities: {
+      streaming: true,
+      tools: true,
+      images: 'input',
+      systemPrompt: true,
+    },
     async generate(request) {
       const model = request.model ?? options.model ?? process.env.ANTHROPIC_MODEL;
       if (!model) {
@@ -34,6 +44,62 @@ export function anthropic(options: AnthropicProviderOptions = {}): ModelProvider
         signal: request.signal,
       });
       return fromAnthropicMessage(message);
+    },
+    async *stream(request): AsyncGenerator<StreamEvent> {
+      const model = request.model ?? options.model ?? process.env.ANTHROPIC_MODEL;
+      if (!model) {
+        throw new Error('No Anthropic model configured. Pass `model` to anthropic() or the request builder.');
+      }
+      const defaults: AnthropicRequestDefaults = {
+        model,
+        maxOutputTokens: options.maxOutputTokens,
+        thinking: options.thinking,
+      };
+      const params = toAnthropicRequest(request, defaults);
+      const stream = client.messages.stream({ ...params }, { signal: request.signal });
+
+      const toolCalls = new Map<number, { id: string; name: string; arguments: string }>();
+
+      for await (const event of stream) {
+        if (event.type === 'content_block_start' && event.content_block.type === 'tool_use') {
+          toolCalls.set(event.index, {
+            id: event.content_block.id,
+            name: event.content_block.name,
+            arguments: '',
+          });
+        } else if (event.type === 'content_block_delta') {
+          if (event.delta.type === 'text_delta') {
+            yield { type: 'text-delta', text: event.delta.text };
+          } else if (event.delta.type === 'input_json_delta') {
+            const current = toolCalls.get(event.index);
+            if (current) {
+              current.arguments += event.delta.partial_json;
+              yield {
+                type: 'tool-call-delta',
+                id: current.id,
+                name: current.name,
+                argumentsDelta: event.delta.partial_json,
+              };
+            }
+          }
+        } else if (event.type === 'message_delta' && event.usage) {
+          yield {
+            type: 'usage',
+            usage: {
+              outputTokens: event.usage.output_tokens,
+              totalTokens: event.usage.output_tokens,
+            },
+          };
+        }
+      }
+
+      const result = fromAnthropicMessage(await stream.finalMessage());
+      for (const part of result.parts) {
+        if (part.type === 'toolCall') {
+          yield { type: 'tool-call', toolCall: part.toolCall };
+        }
+      }
+      yield { type: 'done', result };
     },
   };
 }

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -83,11 +83,11 @@ export function anthropic(options: AnthropicProviderOptions = {}): ModelProvider
             }
           }
         } else if (event.type === 'message_delta' && event.usage) {
+          // message_delta only reports output tokens; omit total until finalMessage.
           yield {
             type: 'usage',
             usage: {
               outputTokens: event.usage.output_tokens,
-              totalTokens: event.usage.output_tokens,
             },
           };
         }

--- a/src/providers/compatibility.fixtures.test.ts
+++ b/src/providers/compatibility.fixtures.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { toAnthropicMessages, toAnthropicRequest, toAnthropicSystem } from './anthropic-converter.js';
+import { multimodalToolRoundTripPrompt, sampleTools } from './fixtures/multimodal-tool-roundtrip.js';
+import { toGoogleContents, toGoogleRequest, toGoogleSystemInstruction } from './google-converter.js';
+import { toOpenAIMessages, toOpenAIRequest } from './openai-converter.js';
+
+describe('compatibility fixtures', () => {
+  it('round-trips the shared multimodal tool fixture across converters', () => {
+    const openaiMessages = toOpenAIMessages(multimodalToolRoundTripPrompt);
+    const anthropicMessages = toAnthropicMessages(multimodalToolRoundTripPrompt);
+    const googleContents = toGoogleContents(multimodalToolRoundTripPrompt);
+
+    expect(openaiMessages.some((message) => message.role === 'tool')).toBe(true);
+    expect(anthropicMessages[0]?.role).toBe('assistant');
+    expect(googleContents[0]?.role).toBe('model');
+
+    expect(toOpenAIRequest({ prompt: multimodalToolRoundTripPrompt, tools: sampleTools }, 'm').tools).toHaveLength(1);
+    expect(
+      toAnthropicRequest(
+        { prompt: multimodalToolRoundTripPrompt, tools: sampleTools },
+        { model: 'm' },
+      ).tools,
+    ).toHaveLength(1);
+    expect(toGoogleRequest({ prompt: multimodalToolRoundTripPrompt, tools: sampleTools }, { model: 'm' }).config?.tools)
+      .toBeTruthy();
+
+    expect(toAnthropicSystem(multimodalToolRoundTripPrompt)[0]?.text).toContain('captions');
+    expect(toGoogleSystemInstruction(multimodalToolRoundTripPrompt)?.parts?.[0]).toMatchObject({
+      text: expect.stringContaining('captions'),
+    });
+  });
+});

--- a/src/providers/fixtures/multimodal-tool-roundtrip.ts
+++ b/src/providers/fixtures/multimodal-tool-roundtrip.ts
@@ -1,0 +1,34 @@
+import type { PromptItem, ToolDefinition } from '../../core/types.js';
+
+/** Shared multimodal + tool-call prompt used by converter contract tests. */
+export const multimodalToolRoundTripPrompt: PromptItem[] = [
+  { type: 'systemPrompt', systemPrompt: 'Return captions and call tools when needed.' },
+  {
+    type: 'assistant',
+    text: 'checking',
+    toolCalls: [{ id: 'call-1', name: 'lookup', arguments: { id: 7 } }],
+  },
+  {
+    type: 'user',
+    toolResults: [{ callId: 'call-1', name: 'lookup', content: '{"ok":true}' }],
+    text: 'continue',
+  },
+  {
+    type: 'user',
+    text: 'caption',
+    images: [{ mediaType: 'image/png', data: 'aGVsbG8=' }],
+  },
+];
+
+export const sampleTools: ToolDefinition[] = [
+  {
+    name: 'lookup',
+    description: 'Look up a record by id',
+    parameters: {
+      type: 'object',
+      properties: { id: { type: 'number' } },
+      required: ['id'],
+      additionalProperties: false,
+    },
+  },
+];

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -1,5 +1,5 @@
 import { GoogleGenAI, type GenerateContentConfig, type GoogleGenAIOptions } from '@google/genai';
-import type { ModelProvider } from '../core/types.js';
+import type { ModelProvider, StreamEvent } from '../core/types.js';
 import { fromGoogleResponse, toGoogleRequest, type GoogleRequestDefaults } from './google-converter.js';
 
 type GoogleGenerationDefaults = Omit<
@@ -34,6 +34,12 @@ function googleProvider(
   const client = new GoogleGenAI(clientOptions);
   return {
     name,
+    capabilities: {
+      streaming: true,
+      tools: true,
+      images: 'both',
+      systemPrompt: true,
+    },
     async generate(request) {
       const selectedModel = request.model ?? model;
       if (!selectedModel) {
@@ -42,6 +48,65 @@ function googleProvider(
       const defaults: GoogleRequestDefaults = { model: selectedModel, config: generationConfig };
       const response = await client.models.generateContent(toGoogleRequest(request, defaults));
       return fromGoogleResponse(response);
+    },
+    async *stream(request): AsyncGenerator<StreamEvent> {
+      const selectedModel = request.model ?? model;
+      if (!selectedModel) {
+        throw new Error(`No ${name} model configured. Pass a model to the provider or the request builder.`);
+      }
+      const defaults: GoogleRequestDefaults = { model: selectedModel, config: generationConfig };
+      const googleRequest = toGoogleRequest(request, defaults);
+      const stream = await client.models.generateContentStream({
+        ...googleRequest,
+        config: {
+          ...googleRequest.config,
+          abortSignal: request.signal,
+        },
+      });
+
+      let text = '';
+      let lastResponse: Parameters<typeof fromGoogleResponse>[0] | undefined;
+
+      for await (const chunk of stream) {
+        lastResponse = chunk;
+        const piece = chunk.text ?? '';
+        if (piece) {
+          // Google SDK `text` is cumulative per stream chunk in some versions; prefer delta when possible.
+          const delta = piece.startsWith(text) ? piece.slice(text.length) : piece;
+          if (delta) {
+            text += delta;
+            yield { type: 'text-delta', text: delta };
+          }
+        }
+      }
+
+      if (!lastResponse) {
+        yield { type: 'done', result: { parts: text ? [{ type: 'text', text }] : [] } };
+        return;
+      }
+
+      const result = fromGoogleResponse(lastResponse);
+      // If the final chunk only had partial text, prefer accumulated streamed text when present.
+      if (text && result.parts.every((part) => part.type !== 'text')) {
+        result.parts = [{ type: 'text', text }, ...result.parts];
+      } else if (text) {
+        const textPart = result.parts.find((part) => part.type === 'text');
+        if (textPart && textPart.type === 'text' && textPart.text.length < text.length) {
+          textPart.text = text;
+        }
+      }
+
+      for (const part of result.parts) {
+        if (part.type === 'toolCall') {
+          yield { type: 'tool-call', toolCall: part.toolCall };
+        } else if (part.type === 'image') {
+          yield { type: 'image', image: part.image };
+        }
+      }
+      if (result.usage) {
+        yield { type: 'usage', usage: result.usage };
+      }
+      yield { type: 'done', result };
     },
   };
 }

--- a/src/providers/openai-converter.test.ts
+++ b/src/providers/openai-converter.test.ts
@@ -1,30 +1,14 @@
 import OpenAI from 'openai';
 import { describe, expect, it } from 'vitest';
+import { multimodalToolRoundTripPrompt, sampleTools } from './fixtures/multimodal-tool-roundtrip.js';
 import { fromOpenAICompletion, toOpenAIMessages, toOpenAIRequest } from './openai-converter.js';
 
 describe('OpenAI converter', () => {
   it('converts multimodal prompts and tool round trips', () => {
-    const messages = toOpenAIMessages([
-      { type: 'systemPrompt', systemPrompt: 'rules' },
-      {
-        type: 'assistant',
-        text: 'checking',
-        toolCalls: [{ id: 'call-1', name: 'lookup', arguments: { id: 7 } }],
-      },
-      {
-        type: 'user',
-        toolResults: [{ callId: 'call-1', name: 'lookup', content: '{"ok":true}' }],
-        text: 'continue',
-      },
-      {
-        type: 'user',
-        text: 'caption',
-        images: [{ mediaType: 'image/png', data: 'aGVsbG8=' }],
-      },
-    ]);
+    const messages = toOpenAIMessages(multimodalToolRoundTripPrompt);
 
     expect(messages).toMatchObject([
-      { role: 'system', content: 'rules' },
+      { role: 'system', content: 'Return captions and call tools when needed.' },
       { role: 'assistant', tool_calls: [{ id: 'call-1', function: { name: 'lookup' } }] },
       { role: 'tool', tool_call_id: 'call-1' },
       { role: 'user', content: 'continue' },
@@ -43,7 +27,7 @@ describe('OpenAI converter', () => {
       toOpenAIRequest(
         {
           prompt: [{ type: 'user', text: 'hello' }],
-          tools: [{ name: 'answer', description: 'Answer', parameters: { type: 'object' } }],
+          tools: sampleTools.map((tool) => ({ ...tool, name: 'answer', description: 'Answer' })),
           toolChoice: { name: 'answer' },
         },
         'model-a',

--- a/src/providers/openai-converter.ts
+++ b/src/providers/openai-converter.ts
@@ -4,6 +4,8 @@ import type {
   GenerationResult,
   PromptItem,
   ResultPart,
+  StreamEvent,
+  TokenUsage,
   ToolChoice,
   ToolDefinition,
 } from '../core/types.js';
@@ -128,4 +130,92 @@ export function toOpenAIRequest(request: GenerationRequest, defaultModel: string
     tools: toOpenAITools(request.tools),
     tool_choice: toOpenAIToolChoice(request.toolChoice),
   } satisfies OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming;
+}
+
+export function toOpenAIStreamRequest(request: GenerationRequest, defaultModel: string) {
+  return {
+    ...toOpenAIRequest(request, defaultModel),
+    stream: true as const,
+    stream_options: { include_usage: true },
+  } satisfies OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming;
+}
+
+/**
+ * Accumulate OpenAI chat completion chunks into StreamEvents.
+ * Tool-call argument fragments are emitted as `tool-call-delta` and finalized on `done`.
+ */
+export async function* fromOpenAIStream(
+  chunks: AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk>,
+): AsyncGenerator<StreamEvent> {
+  let text = '';
+  const toolCalls = new Map<number, { id?: string; name?: string; arguments: string }>();
+  let model: string | undefined;
+  let finishReason: string | undefined;
+  let usage: TokenUsage | undefined;
+  let raw: OpenAI.Chat.Completions.ChatCompletionChunk | undefined;
+
+  for await (const chunk of chunks) {
+    raw = chunk;
+    model = chunk.model ?? model;
+    if (chunk.usage) {
+      usage = {
+        inputTokens: chunk.usage.prompt_tokens,
+        outputTokens: chunk.usage.completion_tokens,
+        totalTokens: chunk.usage.total_tokens,
+        cachedInputTokens: chunk.usage.prompt_tokens_details?.cached_tokens,
+      };
+      yield { type: 'usage', usage };
+    }
+
+    const choice = chunk.choices[0];
+    if (!choice) continue;
+    finishReason = choice.finish_reason ?? finishReason;
+
+    const delta = choice.delta;
+    if (delta.content) {
+      text += delta.content;
+      yield { type: 'text-delta', text: delta.content };
+    }
+
+    for (const call of delta.tool_calls ?? []) {
+      const current = toolCalls.get(call.index) ?? { arguments: '' };
+      if (call.id) current.id = call.id;
+      if (call.function?.name) current.name = call.function.name;
+      if (call.function?.arguments) {
+        current.arguments += call.function.arguments;
+        yield {
+          type: 'tool-call-delta',
+          id: current.id,
+          name: current.name,
+          argumentsDelta: call.function.arguments,
+        };
+      }
+      toolCalls.set(call.index, current);
+    }
+  }
+
+  const parts: ResultPart[] = [];
+  if (text) parts.push({ type: 'text', text });
+
+  for (const call of toolCalls.values()) {
+    if (!call.name) continue;
+    const toolCall = {
+      id: call.id,
+      name: call.name,
+      arguments: parseArguments(call.arguments),
+    };
+    parts.push({ type: 'toolCall', toolCall });
+    yield { type: 'tool-call', toolCall };
+  }
+
+  yield {
+    type: 'done',
+    result: {
+      parts,
+      model,
+      finishReason: finishReason ?? undefined,
+      usage,
+      raw,
+    },
+  };
 }

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,6 +1,6 @@
 import OpenAI from 'openai';
 import type { ModelProvider } from '../core/types.js';
-import { fromOpenAICompletion, toOpenAIRequest } from './openai-converter.js';
+import { fromOpenAICompletion, fromOpenAIStream, toOpenAIRequest, toOpenAIStreamRequest } from './openai-converter.js';
 
 export interface OpenAIProviderOptions {
   apiKey?: string;
@@ -21,6 +21,12 @@ export function openai(options: OpenAIProviderOptions = {}): ModelProvider {
 
   return {
     name: 'openai',
+    capabilities: {
+      streaming: true,
+      tools: true,
+      images: 'input',
+      systemPrompt: true,
+    },
     async generate(request) {
       const model = request.model ?? defaultModel;
       if (!model) {
@@ -30,6 +36,16 @@ export function openai(options: OpenAIProviderOptions = {}): ModelProvider {
         signal: request.signal,
       });
       return fromOpenAICompletion(completion);
+    },
+    async *stream(request) {
+      const model = request.model ?? defaultModel;
+      if (!model) {
+        throw new Error('No OpenAI model configured. Pass `model` to openai() or the request builder.');
+      }
+      const chunks = await client.chat.completions.create(toOpenAIStreamRequest(request, model), {
+        signal: request.signal,
+      });
+      yield* fromOpenAIStream(chunks);
     },
   };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements the remaining Phase 3 backend ergonomics and Phase 4 hardening items from `docs/pivot.md`.

### Phase 3
- **Streaming IR:** `StreamEvent` plus `.stream()` / `.streamText()` on builders and chains; native streams for OpenAI, Anthropic, and Google, with generate→stream fallback
- **Middleware:** `timingPlugin`, `rateLimitPlugin`, `cachePlugin`, `fallbackPlugin`, `fallbackProvider`
- **Examples:** `examples/http-handler.ts`, `queue-worker.ts`, `cron-job.ts`
- **Provider packages:** evaluated and documented — keep bundled for 2.x (`docs/provider-packages.md`)

### Phase 4
- **Capabilities:** `ProviderCapabilities` on `ModelProvider` (declared by built-in adapters)
- **Retry guidance:** `classifyError` / `isRetryable` / `withRetry` + `docs/retry.md`
- **Compatibility fixtures:** shared multimodal/tool-call fixture + cross-converter test
- **Semver policy:** `docs/semver.md`

### Copilot review follow-ups
- Enforce `minIntervalMs` between successive starts even when no call is in flight
- `fallbackProvider.stream()` uses the first provider that implements `stream()`
- Anthropic mid-stream usage omits misleading `totalTokens` (output-only until final)

## Test plan
- [x] `npm run check` (type-check, lint, unit tests, build)
- [x] Added unit coverage for min-interval rate limiting and fallback native streaming
- [ ] Manual smoke of `.streamText()` against a live provider when credentials are available
- [ ] Skim docs links from README (`retry`, `semver`, `provider-packages`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3b111d3-a911-44c4-9a66-1a1dc4e06b4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3b111d3-a911-44c4-9a66-1a1dc4e06b4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

