### PR TITLE
chore: cut 2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+## 2.1.0 — 2026-07-25
+
+Publishes the Phase 3–4 work already on `master`. npm `2.0.0` shipped the 2.0
+kernel and provider adapters only; this minor adds the remaining public surface
+documented in the README and [semver policy](docs/semver.md).
+
+### Added
+
+- Provider-neutral streaming (`StreamEvent`, `.stream()` / `.streamText()`,
+  native streams for OpenAI / Anthropic / Google with generate→stream fallback)
+- Built-in middleware: `timingPlugin`, `rateLimitPlugin`, `cachePlugin`,
+  `fallbackPlugin`, `fallbackProvider`
+- Retry helpers: `classifyError`, `isRetryable`, `withRetry` (+ [docs/retry.md](docs/retry.md))
+- `ProviderCapabilities` on `ModelProvider`
+- Compatibility fixtures for multimodal and tool-call round trips
+- Framework examples under `examples/` (HTTP handler, queue worker, cron job)
+- Written guidance: [docs/semver.md](docs/semver.md),
+  [docs/provider-packages.md](docs/provider-packages.md)
+
+### Notes
+
+- Additive API only; no breaking changes from `2.0.0`.
+- Retries remain opt-in application policy (no hidden retries in core).
+- Provider SDKs stay bundled behind `genaicode/providers` for 2.x.
+
+## 2.0.0 — 2026-07-24
+
+Major pivot from coding agent to backend LLM toolkit.
+
+- `genaicode()` client, immutable request builders, conversation chains
+- `PromptItem` IR and prompt/result helpers
+- OpenAI, OpenAI-compatible, Anthropic, Gemini, and Vertex adapters
+- `GenAIPlugin` middleware contract
+- Coding-agent CLI/UI/tools removed; `npx genaicode` prints migration guidance
+  (1.x remains on the `1.x` branch / `genaicode@1`)

--- a/docs/pivot.md
+++ b/docs/pivot.md
@@ -96,6 +96,12 @@ and in the 1.x npm line.
 - Stable extension contracts and a written semver policy — implemented
   ([semver.md](./semver.md)).
 
+### Release status
+
+- `2.0.0` on npm shipped the Phase 1–2 kernel and provider adapters.
+- `2.1.0` publishes Phases 3–4 (streaming, middleware, capabilities, retry
+  helpers, fixtures, examples, and related docs). See [CHANGELOG.md](../CHANGELOG.md).
+
 ## Success measures
 
 - A first model call needs fewer than ten lines of application code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genaicode",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genaicode",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genaicode",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A small, provider-neutral TypeScript toolkit for calling LLMs from backend code.",
   "author": "Grzegorz Tańczyk",
   "repository": {
@@ -27,6 +27,7 @@
   "files": [
     "dist",
     "docs",
+    "CHANGELOG.md",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cuts **genaicode@2.1.0** so npm can ship the Phase 3–4 surface already on `master`.

npm `2.0.0` only contains the Phase 1–2 kernel (no streaming/middleware/retry helpers). This bump is additive per `docs/semver.md`.

### Changes
- Bump `package.json` / lockfile to `2.1.0`
- Add `CHANGELOG.md` (2.0.0 + 2.1.0)
- Include `CHANGELOG.md` in the published `files` list
- Note release status in `docs/pivot.md`

### Publish checklist (after merge)
This environment has no npm auth, so publish from a machine with rights:

```bash
git checkout master && git pull
npm run check
npm publish
gh release create v2.1.0 --title "v2.1.0" --notes-file CHANGELOG.md
```

Verify:

```bash
npm view genaicode version   # expect 2.1.0
npm pack genaicode@2.1.0 --dry-run   # should list dist/core/{stream,middleware,errors}.js
```

### Test plan
- [x] `npm run check`
- [x] `npm pack --dry-run` includes streaming/middleware/errors + docs + CHANGELOG
- [ ] `npm publish` after merge (maintainer)
- [ ] GitHub release `v2.1.0` after publish (maintainer)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4839b61e-3b2f-4f4d-aca2-ecf77bf9a129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4839b61e-3b2f-4f4d-aca2-ecf77bf9a129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

