### PR TITLE
docs: add why GenAIcode vs a raw provider SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Provider SDKs are the right tool when you call one vendor and own every request 
 yourself. The cost shows up when the same backend needs a second provider, a test double,
 or shared policy (timeouts, JSON parsing, rate limits, fallback) without copying glue.
 
-GenAicode is that thin shared layer:
+GenAIcode is that thin shared layer:
 
 - One portable prompt/tool IR (`PromptItem`) instead of OpenAI messages vs Anthropic
   blocks vs Gemini contents.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ npm install genaicode
 
 Node.js 20 or newer is required.
 
+## Why this vs a raw SDK
+
+Provider SDKs are the right tool when you call one vendor and own every request shape
+yourself. The cost shows up when the same backend needs a second provider, a test double,
+or shared policy (timeouts, JSON parsing, rate limits, fallback) without copying glue.
+
+GenAicode is that thin shared layer:
+
+- One portable prompt/tool IR (`PromptItem`) instead of OpenAI messages vs Anthropic
+  blocks vs Gemini contents.
+- One request API (`.text()`, `.json()`, `.stream()`, chains) over those adapters.
+- A tiny `ModelProvider` seam so tests and custom gateways do not mock vendor HTTP.
+- Opt-in middleware and retry helpers—no hidden tool runners, no silent retries, no
+  agent loop.
+
+If you are happy importing one SDK and never swapping models or providers, stay on the
+SDK. If you want the call site to look the same while the edge stays replaceable, use
+GenAIcode.
+
 ## A prompt in three lines
 
 ```ts


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a short **Why this vs a raw SDK** section to the README (right after Install): when a single vendor SDK is enough, and what GenAIcode adds (portable IR, one request API, `ModelProvider` tests, opt-in middleware/retries—without an agent loop).

Docs-only; no version bump.

## Test plan
- [x] Skim section in rendered README context
- [ ] Merge when happy (ready for `master`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4839b61e-3b2f-4f4d-aca2-ecf77bf9a129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4839b61e-3b2f-4f4d-aca2-ecf77bf9a129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

