### PR TITLE
fix(google): honor defaults.config.thinkingConfig and floor Gemini 3.7/Pro to LOW

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ const verdict = await ai(promptText)
   `low` | `medium` | `high`). Prefer one of budget or level — some providers reject both.
   On Google/Gemini, `false` and `budgetTokens: 0` map to `thinkingLevel: MINIMAL`
   because Gemini 3 rejects `thinkingBudget: 0`. JSON `responseFormat` without an
-  explicit `thinking` setting also defaults Google to `MINIMAL`.
+  explicit `thinking` setting or provider `generationConfig.thinkingConfig` default also
+  defaults Google to `MINIMAL`.
 
 Providers map what they support and ignore the rest. `ProviderCapabilities.jsonResponse`
 and `ProviderCapabilities.thinking` advertise support. Vendor-specific escapes such as

--- a/README.md
+++ b/README.md
@@ -180,9 +180,10 @@ const verdict = await ai(promptText)
 - `thinking`: `false` to disable, or `{ budgetTokens?, level? }` (`minimal` |
   `low` | `medium` | `high`). Prefer one of budget or level — some providers reject both.
   On Google/Gemini, `false` and `budgetTokens: 0` map to `thinkingLevel: MINIMAL`
+  (or `LOW` for models like Gemini 3.7 and Gemini 3 Pro where `MINIMAL` is unsupported)
   because Gemini 3 rejects `thinkingBudget: 0`. JSON `responseFormat` without an
   explicit `thinking` setting or provider `generationConfig.thinkingConfig` default also
-  defaults Google to `MINIMAL`.
+  defaults Google thinking to `MINIMAL` (or `LOW` on Gemini 3.7 / Pro).
 
 Providers map what they support and ignore the rest. `ProviderCapabilities.jsonResponse`
 and `ProviderCapabilities.thinking` advertise support. Vendor-specific escapes such as

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genaicode",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genaicode",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",

--- a/src/providers/google-converter.test.ts
+++ b/src/providers/google-converter.test.ts
@@ -1,4 +1,4 @@
-import type { GenerateContentResponse } from '@google/genai';
+import { ThinkingLevel, type GenerateContentResponse } from '@google/genai';
 import { describe, expect, it } from 'vitest';
 import {
   fromGoogleResponse,
@@ -78,6 +78,34 @@ describe('Google converter', () => {
       responseMimeType: 'application/json',
       thinkingConfig: { thinkingLevel: 'MINIMAL' },
     });
+
+    // Provider defaults.config.thinkingConfig is preserved when request has no explicit thinking
+    expect(
+      toGoogleRequest(
+        { prompt: [{ type: 'user', text: 'hello' }], responseFormat: { type: 'json' } },
+        { model: 'gemini-test', config: { thinkingConfig: { thinkingLevel: ThinkingLevel.LOW } } },
+      ).config,
+    ).toMatchObject({
+      responseMimeType: 'application/json',
+      thinkingConfig: { thinkingLevel: ThinkingLevel.LOW },
+    });
+
+    // Request-level thinking overrides provider defaults.config.thinkingConfig
+    expect(
+      toGoogleRequest(
+        { prompt: [{ type: 'user', text: 'hello' }], thinking: { level: 'high' } },
+        { model: 'gemini-test', config: { thinkingConfig: { thinkingLevel: ThinkingLevel.LOW } } },
+      ).config,
+    ).toMatchObject({
+      thinkingConfig: { thinkingLevel: ThinkingLevel.HIGH },
+    });
+
+    expect(
+      toGoogleRequest(
+        { prompt: [{ type: 'user', text: 'hello' }], thinking: false },
+        { model: 'gemini-test', config: { thinkingConfig: { thinkingLevel: ThinkingLevel.LOW } } },
+      ).config,
+    ).toMatchObject({ thinkingConfig: { thinkingLevel: ThinkingLevel.MINIMAL } });
 
     expect(
       toGoogleRequest({ prompt: [{ type: 'user', text: 'hello' }], thinking: false }, { model: 'gemini-test' }).config,

--- a/src/providers/google-converter.test.ts
+++ b/src/providers/google-converter.test.ts
@@ -118,6 +118,56 @@ describe('Google converter', () => {
       ).config,
     ).toMatchObject({ thinkingConfig: { thinkingBudget: 128 } });
 
+    // Model-aware thinking level floor: Gemini 3.7 and Gemini 3+ Pro models floor to LOW
+    expect(
+      toGoogleRequest(
+        { prompt: [{ type: 'user', text: 'hello' }], responseFormat: { type: 'json' } },
+        { model: 'gemini-3.7-flash' },
+      ).config,
+    ).toMatchObject({
+      responseMimeType: 'application/json',
+      thinkingConfig: { thinkingLevel: ThinkingLevel.LOW },
+    });
+
+    expect(
+      toGoogleRequest(
+        { prompt: [{ type: 'user', text: 'hello' }], thinking: false },
+        { model: 'gemini-3.7-flash' },
+      ).config,
+    ).toMatchObject({ thinkingConfig: { thinkingLevel: ThinkingLevel.LOW } });
+
+    expect(
+      toGoogleRequest(
+        { prompt: [{ type: 'user', text: 'hello' }], thinking: { budgetTokens: 0 } },
+        { model: 'gemini-3.7-flash' },
+      ).config,
+    ).toMatchObject({ thinkingConfig: { thinkingLevel: ThinkingLevel.LOW } });
+
+    expect(
+      toGoogleRequest(
+        { prompt: [{ type: 'user', text: 'hello' }], thinking: false },
+        { model: 'gemini-3.1-pro-preview' },
+      ).config,
+    ).toMatchObject({ thinkingConfig: { thinkingLevel: ThinkingLevel.LOW } });
+
+    expect(
+      toGoogleRequest(
+        { prompt: [{ type: 'user', text: 'hello' }], responseFormat: { type: 'json' } },
+        { model: 'gemini-3.6-flash' },
+      ).config,
+    ).toMatchObject({
+      responseMimeType: 'application/json',
+      thinkingConfig: { thinkingLevel: ThinkingLevel.MINIMAL },
+    });
+
+    // Explicit request thinking level is always respected even if caller asks for minimal on 3.7
+    expect(
+      toGoogleRequest(
+        { prompt: [{ type: 'user', text: 'hello' }], thinking: { level: 'minimal' } },
+        { model: 'gemini-3.7-flash' },
+      ).config,
+    ).toMatchObject({ thinkingConfig: { thinkingLevel: ThinkingLevel.MINIMAL } });
+
     const response = {
       modelVersion: 'gemini-test',
       candidates: [

--- a/src/providers/google-converter.ts
+++ b/src/providers/google-converter.ts
@@ -119,18 +119,30 @@ const googleThinkingLevels = {
   high: ThinkingLevel.HIGH,
 } as const;
 
-function toGoogleThinkingConfig(thinking: ThinkingConfig | undefined): GenerateContentConfig['thinkingConfig'] {
-  if (thinking === undefined) return undefined;
-  // Gemini 3 rejects `thinkingBudget: 0` (INVALID_ARGUMENT). `MINIMAL` is the
-  // supported "keep it cheap / effectively off" setting for those models.
-  if (thinking === false || thinking.budgetTokens === 0) {
+function toGoogleThinkingConfig(
+  thinking: ThinkingConfig | undefined,
+  fallback: GenerateContentConfig['thinkingConfig'] | undefined,
+  wantsJson: boolean,
+): GenerateContentConfig['thinkingConfig'] {
+  if (thinking === false || thinking?.budgetTokens === 0) {
+    // Gemini 3 rejects `thinkingBudget: 0` (INVALID_ARGUMENT). `MINIMAL` is the
+    // supported "keep it cheap / effectively off" setting for those models.
     return { thinkingLevel: ThinkingLevel.MINIMAL };
   }
-  if (thinking.level) {
+  if (thinking?.level) {
     return { thinkingLevel: googleThinkingLevels[thinking.level] };
   }
-  if (thinking.budgetTokens !== undefined) {
+  if (thinking?.budgetTokens !== undefined) {
     return { thinkingBudget: thinking.budgetTokens };
+  }
+  if (fallback !== undefined) {
+    return fallback;
+  }
+  if (wantsJson) {
+    // Gemini 3 defaults to heavy dynamic thinking; with a small maxOutputTokens budget that
+    // can yield an empty visible answer under JSON mode. Prefer MINIMAL when neither the caller
+    // nor the provider set thinking explicitly.
+    return { thinkingLevel: ThinkingLevel.MINIMAL };
   }
   return undefined;
 }
@@ -142,11 +154,7 @@ export function toGoogleRequest(
   const hasTools = Boolean(request.tools?.length);
   const responseFormat = toGoogleResponseFormat(request.responseFormat);
   const wantsJson = request.responseFormat?.type === 'json' || request.responseFormat?.type === 'json_schema';
-  // Gemini 3 defaults to heavy dynamic thinking; with a small maxOutputTokens budget that
-  // can yield an empty visible answer under JSON mode. Prefer MINIMAL when the caller did
-  // not set thinking explicitly.
-  const thinkingConfig =
-    toGoogleThinkingConfig(request.thinking) ?? (wantsJson ? { thinkingLevel: ThinkingLevel.MINIMAL } : undefined);
+  const thinkingConfig = toGoogleThinkingConfig(request.thinking, defaults.config?.thinkingConfig, wantsJson);
   return {
     model: request.model ?? defaults.model,
     contents: toGoogleContents(request.prompt),

--- a/src/providers/google-converter.ts
+++ b/src/providers/google-converter.ts
@@ -119,15 +119,27 @@ const googleThinkingLevels = {
   high: ThinkingLevel.HIGH,
 } as const;
 
+function defaultDisabledThinkingLevel(model: string | undefined): ThinkingLevel {
+  if (!model) return ThinkingLevel.MINIMAL;
+  const normalized = model.toLowerCase();
+  // Gemini 3.7 models and Gemini 3+ Pro models do not support MINIMAL (their floor is LOW).
+  if (/gemini-3\.7/i.test(normalized) || /gemini-3(?:\.[0-9]+)?-pro/i.test(normalized)) {
+    return ThinkingLevel.LOW;
+  }
+  return ThinkingLevel.MINIMAL;
+}
+
 function toGoogleThinkingConfig(
   thinking: ThinkingConfig | undefined,
   fallback: GenerateContentConfig['thinkingConfig'] | undefined,
   wantsJson: boolean,
+  model: string | undefined,
 ): GenerateContentConfig['thinkingConfig'] {
   if (thinking === false || thinking?.budgetTokens === 0) {
     // Gemini 3 rejects `thinkingBudget: 0` (INVALID_ARGUMENT). `MINIMAL` is the
-    // supported "keep it cheap / effectively off" setting for those models.
-    return { thinkingLevel: ThinkingLevel.MINIMAL };
+    // supported "keep it cheap / effectively off" setting for models that support it,
+    // while models like Gemini 3.7 and Gemini 3 Pro floor at `LOW`.
+    return { thinkingLevel: defaultDisabledThinkingLevel(model) };
   }
   if (thinking?.level) {
     return { thinkingLevel: googleThinkingLevels[thinking.level] };
@@ -140,9 +152,9 @@ function toGoogleThinkingConfig(
   }
   if (wantsJson) {
     // Gemini 3 defaults to heavy dynamic thinking; with a small maxOutputTokens budget that
-    // can yield an empty visible answer under JSON mode. Prefer MINIMAL when neither the caller
-    // nor the provider set thinking explicitly.
-    return { thinkingLevel: ThinkingLevel.MINIMAL };
+    // can yield an empty visible answer under JSON mode. Prefer MINIMAL (or LOW on models that
+    // floor at LOW) when neither the caller nor the provider set thinking explicitly.
+    return { thinkingLevel: defaultDisabledThinkingLevel(model) };
   }
   return undefined;
 }
@@ -151,12 +163,13 @@ export function toGoogleRequest(
   request: GenerationRequest,
   defaults: GoogleRequestDefaults,
 ): GenerateContentParameters {
+  const model = request.model ?? defaults.model;
   const hasTools = Boolean(request.tools?.length);
   const responseFormat = toGoogleResponseFormat(request.responseFormat);
   const wantsJson = request.responseFormat?.type === 'json' || request.responseFormat?.type === 'json_schema';
-  const thinkingConfig = toGoogleThinkingConfig(request.thinking, defaults.config?.thinkingConfig, wantsJson);
+  const thinkingConfig = toGoogleThinkingConfig(request.thinking, defaults.config?.thinkingConfig, wantsJson, model);
   return {
-    model: request.model ?? defaults.model,
+    model,
     contents: toGoogleContents(request.prompt),
     config: {
       ...defaults.config,

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -12,6 +12,10 @@ export interface GeminiProviderOptions {
   model?: string;
   apiVersion?: string;
   httpOptions?: GoogleGenAIOptions['httpOptions'];
+  /**
+   * Default generation parameters passed to `@google/genai` `config`.
+   * Request-level settings take precedence over values provided here.
+   */
   generationConfig?: GoogleGenerationDefaults;
 }
 
@@ -22,6 +26,10 @@ export interface VertexAIProviderOptions {
   apiVersion?: string;
   googleAuthOptions?: GoogleGenAIOptions['googleAuthOptions'];
   httpOptions?: GoogleGenAIOptions['httpOptions'];
+  /**
+   * Default generation parameters passed to `@google/genai` `config`.
+   * Request-level settings take precedence over values provided here.
+   */
   generationConfig?: GoogleGenerationDefaults;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #88

### Summary of Changes

1. **Precedence fix in `toGoogleRequest` (`src/providers/google-converter.ts`)**:
   - `toGoogleThinkingConfig` now considers the provider default `defaults.config?.thinkingConfig` when `request.thinking` is unset.
   - Preserves provider-level thinking configurations (e.g., `{ thinkingLevel: ThinkingLevel.LOW }` configured on `gemini({ generationConfig: ... })` or `vertexAI({ generationConfig: ... })`) even when requests enable JSON mode without explicitly calling `.thinking(...)`.

2. **Model-aware fallback floor for disabled thinking & JSON mode**:
   - For models that do not support `MINIMAL` (such as `gemini-3.7` models and Gemini 3+ Pro models where the minimum allowed thinking level is `LOW`), portable `.thinking(false)`, `{ budgetTokens: 0 }`, and implicit JSON-mode fallback now automatically floor to `ThinkingLevel.LOW`.
   - Other Gemini models (e.g. `gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`) continue to use `ThinkingLevel.MINIMAL` for the lowest latency and token usage.
   - Explicit user requests for `{ level: 'minimal' }` are passed through untouched.

3. **Documentation & Types (`src/providers/google.ts`, `README.md`)**:
   - Added JSDoc comments to `GeminiProviderOptions.generationConfig` and `VertexAIProviderOptions.generationConfig` documenting the configuration and precedence rules.
   - Updated `README.md` description of Google thinking defaults and model-aware flooring.

4. **Unit Tests (`src/providers/google-converter.test.ts`)**:
   - Added tests verifying `defaults.config.thinkingConfig` preservation in JSON mode.
   - Added tests verifying that `gemini-3.7-flash` and `gemini-3.1-pro-preview` floor portable disablement / JSON mode to `LOW`.
   - Added tests verifying `gemini-3.6-flash` retains `MINIMAL`.
   - Added tests verifying explicit `.thinking({ level: 'minimal' })` is respected on all models.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d843bec-7241-477a-b6e8-ad0fafc3261f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d843bec-7241-477a-b6e8-ad0fafc3261f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

